### PR TITLE
fix #66 - Remove Grand-Est from License and Copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 CGI France - Grand Est
+Copyright (c) 2021 CGI France
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/AzureIoTHub.Portal/Client/Program.cs
+++ b/src/AzureIoTHub.Portal/Client/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CGI France - Grand Est. All rights reserved.
+// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Client

--- a/src/AzureIoTHub.Portal/Client/Shared/MainLayout.razor
+++ b/src/AzureIoTHub.Portal/Client/Shared/MainLayout.razor
@@ -11,7 +11,7 @@
     </MudMainContent>
     <MudAppBar id="footer" Elevation="1" Style="top: auto; bottom: 0" Dense="true" Fixed="true">
         <MudGrid Justify="Justify.Center">
-            <MudText Style="font-size:small">© 2021 Copyright:&nbsp; CGI France - Grand Est</MudText>
+            <MudText Style="font-size:small">© 2021 Copyright:&nbsp; CGI France</MudText>
         </MudGrid>
     </MudAppBar>
 </MudLayout>

--- a/src/AzureIoTHub.Portal/Server/Controllers/ConfigsController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/ConfigsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Controllers/DeviceModelsController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/DeviceModelsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Controllers/DevicesController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/DevicesController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Controllers/GatewaysController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/GatewaysController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Controllers/MSALSettingsController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/MSALSettingsController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Controllers/UsersController.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/UsersController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Controllers

--- a/src/AzureIoTHub.Portal/Server/Extensions/StringExtension.cs
+++ b/src/AzureIoTHub.Portal/Server/Extensions/StringExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Extensions

--- a/src/AzureIoTHub.Portal/Server/Factories/ITableClientFactory.cs
+++ b/src/AzureIoTHub.Portal/Server/Factories/ITableClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Factories

--- a/src/AzureIoTHub.Portal/Server/Factories/TableClientFactory.cs
+++ b/src/AzureIoTHub.Portal/Server/Factories/TableClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Factories

--- a/src/AzureIoTHub.Portal/Server/Filters/ApiRequiredScopeFilter.cs
+++ b/src/AzureIoTHub.Portal/Server/Filters/ApiRequiredScopeFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Filters

--- a/src/AzureIoTHub.Portal/Server/Helpers/ConfigHelper.cs
+++ b/src/AzureIoTHub.Portal/Server/Helpers/ConfigHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Helpers

--- a/src/AzureIoTHub.Portal/Server/Helpers/DeviceHelper.cs
+++ b/src/AzureIoTHub.Portal/Server/Helpers/DeviceHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Helpers

--- a/src/AzureIoTHub.Portal/Server/Identity/B2CExtensionHelper.cs
+++ b/src/AzureIoTHub.Portal/Server/Identity/B2CExtensionHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Identity

--- a/src/AzureIoTHub.Portal/Server/Identity/ClientApiIndentityOptions.cs
+++ b/src/AzureIoTHub.Portal/Server/Identity/ClientApiIndentityOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Identity

--- a/src/AzureIoTHub.Portal/Server/Identity/IB2CExtensionHelper.cs
+++ b/src/AzureIoTHub.Portal/Server/Identity/IB2CExtensionHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Identity

--- a/src/AzureIoTHub.Portal/Server/Interfaces/IConfigs.cs
+++ b/src/AzureIoTHub.Portal/Server/Interfaces/IConfigs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Interfaces

--- a/src/AzureIoTHub.Portal/Server/Managers/ConnectionStringManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/ConnectionStringManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Managers/DeviceModelImageManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/DeviceModelImageManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Managers/IConnectionStringManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/IConnectionStringManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Managers/IDeviceModelImageManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/IDeviceModelImageManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Managers/ILoraDeviceMethodManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/ILoraDeviceMethodManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Managers/LoraDeviceMethodManager.cs
+++ b/src/AzureIoTHub.Portal/Server/Managers/LoraDeviceMethodManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Managers

--- a/src/AzureIoTHub.Portal/Server/Mappers/DeviceModelCommandMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/DeviceModelCommandMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Mappers/DeviceModelMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/DeviceModelMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Mappers/DeviceTwinMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/DeviceTwinMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Mappers/IDeviceModelCommandMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/IDeviceModelCommandMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Mappers/IDeviceModelMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/IDeviceModelMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Mappers/IDeviceTwinMapper.cs
+++ b/src/AzureIoTHub.Portal/Server/Mappers/IDeviceTwinMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Mappers

--- a/src/AzureIoTHub.Portal/Server/Pages/Error.cshtml.cs
+++ b/src/AzureIoTHub.Portal/Server/Pages/Error.cshtml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Pages

--- a/src/AzureIoTHub.Portal/Server/Program.cs
+++ b/src/AzureIoTHub.Portal/Server/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server

--- a/src/AzureIoTHub.Portal/Server/Properties/GlobalSuppressions.cs
+++ b/src/AzureIoTHub.Portal/Server/Properties/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzureIoTHub.Portal/Server/Services/ConfigsServices.cs
+++ b/src/AzureIoTHub.Portal/Server/Services/ConfigsServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Services

--- a/src/AzureIoTHub.Portal/Server/Services/DeviceService.cs
+++ b/src/AzureIoTHub.Portal/Server/Services/DeviceService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Services

--- a/src/AzureIoTHub.Portal/Server/Services/IDeviceService.cs
+++ b/src/AzureIoTHub.Portal/Server/Services/IDeviceService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server.Services

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CGI France - Grand Est. All rights reserved.
+// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Server

--- a/src/AzureIoTHub.Portal/Shared/Models/C2Dresult.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/C2Dresult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/ConfigItem.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/ConfigItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/ConfigListItem.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/ConfigListItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/Device/Command.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/Device/Command.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models.Device

--- a/src/AzureIoTHub.Portal/Shared/Models/Device/DeviceDetails.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/Device/DeviceDetails.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models.Device

--- a/src/AzureIoTHub.Portal/Shared/Models/Device/DeviceListItem.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/Device/DeviceListItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models.Device

--- a/src/AzureIoTHub.Portal/Shared/Models/DeviceModel.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/DeviceModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/DeviceModelCommand.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/DeviceModelCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/Gateway.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/Gateway.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/GatewayListItem.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/GatewayListItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/GatewayModule.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/GatewayModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/RequestPayload.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/RequestPayload.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/Models/SearchModel.cs
+++ b/src/AzureIoTHub.Portal/Shared/Models/SearchModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Models

--- a/src/AzureIoTHub.Portal/Shared/PaginationRequest.cs
+++ b/src/AzureIoTHub.Portal/Shared/PaginationRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared

--- a/src/AzureIoTHub.Portal/Shared/PaginationResult.cs
+++ b/src/AzureIoTHub.Portal/Shared/PaginationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared

--- a/src/AzureIoTHub.Portal/Shared/Security/RoleNames.cs
+++ b/src/AzureIoTHub.Portal/Shared/Security/RoleNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Security

--- a/src/AzureIoTHub.Portal/Shared/Settings/MSALSettings.cs
+++ b/src/AzureIoTHub.Portal/Shared/Settings/MSALSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.Settings

--- a/src/AzureIoTHub.Portal/Shared/UserManagement/UserInvitation.cs
+++ b/src/AzureIoTHub.Portal/Shared/UserManagement/UserInvitation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.UserManagement

--- a/src/AzureIoTHub.Portal/Shared/UserManagement/UserListItem.cs
+++ b/src/AzureIoTHub.Portal/Shared/UserManagement/UserListItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CGI France - Grand Est. All rights reserved.
+﻿// Copyright (c) CGI France. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace AzureIoTHub.Portal.Shared.UserManagement

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "CGI France - Grand Est",
+      "companyName": "CGI France",
       "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the MIT license. See LICENSE file in the project root for full license information.",
       "xmlHeader": false
     },


### PR DESCRIPTION
# Remove Grand-Est from License and Copyright

## Description

From legal perspective we have to remove Grand-Est name from License and Copyright.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other

## Checklist before merge

**Developer's responsibilities**
- [x] This pull request merges to `main`
- [x] Approved by at least one developer
- [x] **Pull request build** has passed
- [ ] Staging app has been deployed successfully

**Product Owner's responsibilities**
- [x] No issues have been found on staging environment
- [ ] Product Owner has approved the release