### PR TITLE
fix #102 - Check if device model is present before requesting the current device model

### DIFF
--- a/src/AzureIoTHub.Portal/Client/Pages/Devices/DeviceDetailPage.razor
+++ b/src/AzureIoTHub.Portal/Client/Pages/Devices/DeviceDetailPage.razor
@@ -184,8 +184,11 @@
             Device = await Http.GetFromJsonAsync<DeviceDetails>($"api/Devices/{DeviceID}");
 
             // Gets the DeviceModel Name from the DeviceModel ID
-            DeviceModel model = await Http.GetFromJsonAsync<DeviceModel>($"api/DeviceModels/{Device.ModelId}");
-            Device.ModelName = model.Name;
+            if (!string.IsNullOrEmpty(Device.ModelId))
+            {
+                DeviceModel model = await Http.GetFromJsonAsync<DeviceModel>($"api/DeviceModels/{Device.ModelId}");
+                Device.ModelName = model?.Name;
+            }
 
             // StatusUpdatedTime set to string to have a more human-readable format
             StatusUpdatedTimeString = Device.StatusUpdatedTime.ToString();


### PR DESCRIPTION
## Description

What's new?

- fix bug in device model page when loading a device that is not creating by the interface (with field missing)

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Checklist before merge

**Developer's responsibilities**
- [x] This pull request merges to `main`
- [x] Approved by at least one developer
- [ ] **Pull request build** has passed
- [x] Staging app has been deployed successfully

**Product Owner's responsibilities**
- [ ] No issues have been found on staging environment
- [ ] Product Owner has approved the release