### PR TITLE
Fix #300 - Remove Action buttons from IoT Edge Configuration

### DIFF
--- a/src/AzureIoTHub.Portal/Client/Pages/Configurations/ConfigDetail.razor
+++ b/src/AzureIoTHub.Portal/Client/Pages/Configurations/ConfigDetail.razor
@@ -13,7 +13,7 @@
 <MudContainer MaxWidth="MaxWidth.False">
     <MudGrid>
         <MudItem xs="12">
-            <EditForm Model="@Config" OnValidSubmit="SaveConfig">
+            <EditForm Model="@Config">
                 <MudCard>
                     <MudCardHeader>
                         <CardHeaderContent>
@@ -76,10 +76,6 @@
                             }
                     </MudCardContent>
                 </MudCard>
-                <MudCardActions>
-                    <MudFab ButtonType="ButtonType.Submit" Color="Color.Secondary" Icon="@Icons.Material.Filled.Save" Label="Save" Disabled="@(!success)" Class="ml-auto" />
-                    <MudFab Color="Color.Dark" Icon="@Icons.Material.Filled.Delete" Label="Delete" OnClick="DeleteConfig" />
-                </MudCardActions>
             </EditForm>
         </MudItem>
     </MudGrid>
@@ -121,8 +117,6 @@
 
     private ConfigListItem Config { get; set; } = new ConfigListItem();
 
-    private bool success = true;
-
     public string ConditionEnv { get; set; }
     public string ConditionType { get; set; }
     public string ConditionOwner { get; set; }
@@ -160,16 +154,6 @@
         {
             return string.Empty;
         }
-    }
-
-    public async void SaveConfig()
-    {
-        await Task.Delay(0); // TODO?
-    }
-
-    private async Task DeleteConfig()
-    {
-        await Task.Delay(0); // TODO?
     }
 
     /// <summary>

--- a/src/AzureIoTHub.Portal/Client/Pages/Configurations/Configs.razor
+++ b/src/AzureIoTHub.Portal/Client/Pages/Configurations/Configs.razor
@@ -41,7 +41,6 @@
                         <MudTh Style="text-align: center">Priority</MudTh>
                         <MudTh Style="text-align: center">Creation date</MudTh>
                         <MudTh Style="text-align: center">Detail</MudTh>
-                        <MudTh Style="text-align: center">Delete</MudTh>
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd DataLabel="ID" Style="word-break: break-all;">
@@ -62,9 +61,6 @@
                         <MudTd DataLabel="Creation date" Style="text-align: center;">@context.CreationDate</MudTd>
                         <MudTd DataLabel="Details" Style="text-align: center">
                             <a href="/edge/configurations/@context.ConfigurationID"><MudIconButton Icon="@Icons.Filled.Visibility" Color="Color.Default" /></a>
-                        </MudTd>
-                        <MudTd DataLabel="Delete" Style="text-align: center">
-                            <MudIconButton Color="Color.Default" Icon="@Icons.Material.Filled.Delete" Size="Size.Medium" OnClick="@(e => DeleteConfiguration(context))"></MudIconButton>
                         </MudTd>
                     </RowTemplate>
                     <PagerContent>
@@ -99,10 +95,5 @@
         {
             exception.Redirect();
         }
-    }
-
-    private async Task DeleteConfiguration(ConfigListItem config)
-    {
-        await Task.Delay(0); //TODO?
     }
 }


### PR DESCRIPTION
## Description

What's new?

- Remove unused action buttons in IoT Edge configuration pages

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other