### PR TITLE
Wait for button is present before continuing test

### DIFF
--- a/src/AzureIoTHub.Portal.Server.Tests.Unit/Pages/Devices/DevicesListPageTests.cs
+++ b/src/AzureIoTHub.Portal.Server.Tests.Unit/Pages/Devices/DevicesListPageTests.cs
@@ -9,6 +9,7 @@ using AzureIoTHub.Portal.Client.Pages.Devices;
 using AzureIoTHub.Portal.Server.Tests.Unit.Helpers;
 using Bunit;
 using Bunit.TestDoubles;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -169,7 +170,7 @@ namespace AzureIoTHub.Portal.Server.Tests.Pages
                 .RespondJson(new object[0]);
 
             var cut = RenderComponent<DeviceListPage>();
-            await Task.Delay(100);
+            cut.WaitForAssertion(() => cut.Find($"#tableRefreshButton"), 1.Seconds());
 
             // Act
             for (int i = 0; i < 3; i++)


### PR DESCRIPTION
## Description

What's new?

- fix #343  - Wait unit a button is present before continuing a test

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other