### PR TITLE
Fix #488  - Use model id in twin configuration names

### DIFF
--- a/src/AzureIoTHub.Portal.Server.Tests.Unit/Controllers/v1.0/DeviceModelsControllerTests.cs
+++ b/src/AzureIoTHub.Portal.Server.Tests.Unit/Controllers/v1.0/DeviceModelsControllerTests.cs
@@ -347,7 +347,6 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Controllers.V10
 
             _ = this.mockConfigService.Setup(c => c.RolloutDeviceConfiguration(
                 It.Is<string>(x => x == requestModel.ModelId),
-                It.Is<string>(x => x == requestModel.Name),
                 It.IsAny<Dictionary<string, object>>()))
                 .Returns(Task.CompletedTask);
 
@@ -402,7 +401,6 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Controllers.V10
 
             _ = this.mockConfigService.Setup(c => c.RolloutDeviceConfiguration(
                 It.Is<string>(x => x == requestModel.ModelId),
-                It.Is<string>(x => x == requestModel.Name),
                 It.IsAny<Dictionary<string, object>>()))
                 .Returns(Task.CompletedTask);
 
@@ -478,7 +476,6 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Controllers.V10
 
             _ = this.mockConfigService.Setup(c => c.RolloutDeviceConfiguration(
                 It.Is<string>(x => x == requestModel.ModelId),
-                It.Is<string>(x => x == requestModel.Name),
                 It.IsAny<Dictionary<string, object>>()))
                 .Returns(Task.CompletedTask);
 

--- a/src/AzureIoTHub.Portal.Server.Tests.Unit/Services/ConfigsServicesTests.cs
+++ b/src/AzureIoTHub.Portal.Server.Tests.Unit/Services/ConfigsServicesTests.cs
@@ -105,7 +105,7 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Services
         [TestCase("aaa", "aaa")]
         [TestCase("AAA", "aaa")]
         [TestCase("AAA AAA", "aaa-aaa")]
-        public async Task RolloutDeviceConfigurationStateUnderTestExpectedBehavior(string deviceType, string configurationPrefix)
+        public async Task RolloutDeviceConfigurationStateUnderTestExpectedBehavior(string modelId, string configurationPrefix)
         {
             // Arrange
             var configsServices = CreateConfigsServices();
@@ -114,8 +114,6 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Services
                 { "prop1", "value1" }
             };
             Configuration newConfiguration = null;
-            var modelId = Guid.NewGuid().ToString();
-
             _ = this.mockRegistryManager.Setup(c => c.GetConfigurationsAsync(It.IsAny<int>()))
                 .ReturnsAsync(Array.Empty<Configuration>());
 
@@ -124,7 +122,7 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Services
                 .ReturnsAsync((Configuration conf) => conf);
 
             // Act
-            await configsServices.RolloutDeviceConfiguration(modelId, deviceType, desiredProperties);
+            await configsServices.RolloutDeviceConfiguration(modelId, desiredProperties);
 
             // Assert
             Assert.IsNotNull(newConfiguration);
@@ -153,7 +151,6 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Services
             };
             Configuration newConfiguration;
             var suffix = Guid.NewGuid().ToString();
-            var modelId = Guid.NewGuid().ToString();
 
             _ = this.mockRegistryManager.Setup(c => c.GetConfigurationsAsync(It.IsAny<int>()))
                 .ReturnsAsync(new Configuration[]
@@ -170,7 +167,7 @@ namespace AzureIoTHub.Portal.Server.Tests.Unit.Services
                 .Returns(Task.CompletedTask);
 
             // Act
-            await configsServices.RolloutDeviceConfiguration(modelId, deviceType, desirectProperties);
+            await configsServices.RolloutDeviceConfiguration(deviceType, desirectProperties);
 
             // Assert
             this.mockRegistryManager.Verify(c => c.GetConfigurationsAsync(It.IsAny<int>()), Times.Once());

--- a/src/AzureIoTHub.Portal/Server/Controllers/v1.0/DeviceModelControllerBase.cs
+++ b/src/AzureIoTHub.Portal/Server/Controllers/v1.0/DeviceModelControllerBase.cs
@@ -380,7 +380,7 @@ namespace AzureIoTHub.Portal.Server.Controllers.V10
 
             _ = await this.deviceProvisioningServiceManager.CreateEnrollmentGroupFromModelAsync(deviceModelObject.ModelId, deviceModelObject.Name, deviceModelTwin);
 
-            await this.configService.RolloutDeviceConfiguration(deviceModelObject.ModelId, deviceModelObject.Name, desiredProperties);
+            await this.configService.RolloutDeviceConfiguration(deviceModelObject.ModelId, desiredProperties);
         }
     }
 }

--- a/src/AzureIoTHub.Portal/Server/Services/ConfigService.cs
+++ b/src/AzureIoTHub.Portal/Server/Services/ConfigService.cs
@@ -38,12 +38,12 @@ namespace AzureIoTHub.Portal.Server.Services
             return this.registryManager.GetConfigurationAsync(id);
         }
 
-        public async Task RolloutDeviceConfiguration(string modelId, string modelName, Dictionary<string, object> desiredProperties)
+        public async Task RolloutDeviceConfiguration(string modelId, Dictionary<string, object> desiredProperties)
         {
             var configurations = await this.registryManager.GetConfigurationsAsync(0);
 
 #pragma warning disable CA1308 // Normalize strings to uppercase
-            var configurationNamePrefix = modelName?.Trim()
+            var configurationNamePrefix = modelId?.Trim()
                                                 .ToLowerInvariant()
                                                 .Replace(" ", "-", StringComparison.OrdinalIgnoreCase);
 #pragma warning restore CA1308 // Normalize strings to uppercase

--- a/src/AzureIoTHub.Portal/Server/Services/IConfigService.cs
+++ b/src/AzureIoTHub.Portal/Server/Services/IConfigService.cs
@@ -13,7 +13,7 @@ namespace AzureIoTHub.Portal.Server.Services
 
         Task<IEnumerable<Configuration>> GetDevicesConfigurations();
 
-        Task RolloutDeviceConfiguration(string modelId, string modelName, Dictionary<string, object> desiredProperties);
+        Task RolloutDeviceConfiguration(string modelId, Dictionary<string, object> desiredProperties);
 
         Task<Configuration> GetConfigItem(string id);
     }


### PR DESCRIPTION
## Description

What's new?

- Fix #488 

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other