### PR TITLE
Fix the reference to the parameter isLoRaFeatureEnabled #548

### DIFF
--- a/templates/portalDeploy.json
+++ b/templates/portalDeploy.json
@@ -198,8 +198,8 @@
             },
             {
               "name": "LoRaFeature__Enabled",
-              "value": "[variables('isLoRaFeatureEnabled')]"
-            }
+              "value": "[parameters('isLoRaFeatureEnabled')]"
+            },
             {
               "name": "LoRaRegionRouterConfig__Url",
               "value": "https://raw.githubusercontent.com/Azure/iotedge-lorawan-starterkit/dev/Tools/Cli-LoRa-Device-Provisioning/DefaultRouterConfig/"


### PR DESCRIPTION
Deployment of the template fails because :
- The template was referencing a non-existent variable called isLoRaFeatureEnabled: Referencing now an existing parameter with same name 
- A comma was missing


## Description

What's new?

- Fix #548

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other