### PR TITLE
Make OIDC token validation configurable (defaults to true)

### DIFF
--- a/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
@@ -21,6 +21,10 @@ namespace AzureIoTHub.Portal.Server
         internal const string OIDCMetadataUrlKey = "OIDC:MetadataUrl";
         internal const string OIDCClientIdKey = "OIDC:ClientId";
         internal const string OIDCApiClientIdKey = "OIDC:ApiClientId";
+        internal const string OIDCValidateIssuerKey = "OIDC:ValidateIssuer";
+        internal const string OIDCValidateAudienceKey = "OIDC:ValidateAudience";
+        internal const string OIDCValidateLifetimeKey = "OIDC:ValidateLifetime";
+        internal const string OIDCValidateIssuerSigningKeyKey = "OIDC:ValidateIssuerSigningKey";
 
         internal const string IsLoRaFeatureEnabledKey = "LoRaFeature:Enabled";
 
@@ -66,6 +70,14 @@ namespace AzureIoTHub.Portal.Server
         internal abstract string OIDCMetadataUrl { get; }
 
         internal abstract string OIDCAuthority { get; }
+
+        internal abstract bool OIDCValidateIssuer { get; }
+
+        internal abstract bool OIDCValidateAudience { get; }
+
+        internal abstract bool OIDCValidateLifetime { get; }
+
+        internal abstract bool OIDCValidateIssuerSigningKey { get; }
 
         internal abstract bool IsLoRaEnabled { get; }
 

--- a/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
@@ -40,6 +40,14 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string OIDCApiClientId => this.config[OIDCApiClientIdKey];
 
+        internal override bool OIDCValidateIssuer => this.config.GetValue(OIDCValidateIssuerKey, true);
+
+        internal override bool OIDCValidateAudience => this.config.GetValue(OIDCValidateAudienceKey, true);
+
+        internal override bool OIDCValidateLifetime => this.config.GetValue(OIDCValidateLifetimeKey, true);
+
+        internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
@@ -40,6 +40,14 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string OIDCApiClientId => this.config[OIDCApiClientIdKey];
 
+        internal override bool OIDCValidateIssuer => this.config.GetValue(OIDCValidateIssuerKey, true);
+
+        internal override bool OIDCValidateAudience => this.config.GetValue(OIDCValidateAudienceKey, true);
+
+        internal override bool OIDCValidateLifetime => this.config.GetValue(OIDCValidateLifetimeKey, true);
+
+        internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -87,10 +87,10 @@ namespace AzureIoTHub.Portal.Server
                     opts.MetadataAddress = configuration.OIDCMetadataUrl;
                     opts.Audience = configuration.OIDCApiClientId;
 
-                    opts.TokenValidationParameters.ValidateIssuer = true;
-                    opts.TokenValidationParameters.ValidateAudience = true;
-                    opts.TokenValidationParameters.ValidateLifetime = true;
-                    opts.TokenValidationParameters.ValidateIssuerSigningKey = true;
+                    opts.TokenValidationParameters.ValidateIssuer = configuration.OIDCValidateIssuer;
+                    opts.TokenValidationParameters.ValidateAudience = configuration.OIDCValidateAudience;
+                    opts.TokenValidationParameters.ValidateLifetime = configuration.OIDCValidateLifetime;
+                    opts.TokenValidationParameters.ValidateIssuerSigningKey = configuration.OIDCValidateIssuerSigningKey;
                 });
 
             _ = services.AddSingleton(configuration);


### PR DESCRIPTION
## Description

What's new?

New options are now present on the portal: 
- OIDC__ValidateIssuer
  > Validation of the issuer mitigates forwarding attacks that can occur when an IdentityProvider represents multiple tenants and signs tokens with the same keys. It is possible that a token issued for the same audience could be from a different tenant. For example an application could accept users from contoso.onmicrosoft.com but not fabrikam.onmicrosoft.com, both valid tenants. An application that accepts tokens from fabrikam could forward them to the application that accepts tokens for contoso. This boolean only applies to default issuer validation. If [IssuerValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.issuervalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-issuervalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateAudience
  > Validation of the audience, mitigates forwarding attacks. For example, a site that receives a token, could not replay it to another side. A forwarded token would contain the audience of the original site. This boolean only applies to default audience validation. If [AudienceValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.audiencevalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-audiencevalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateLifetime
  > This boolean only applies to default lifetime validation. If [LifetimeValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.lifetimevalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-lifetimevalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateIssuerSigningKey
  > It is possible for tokens to contain the public key needed to check the signature. For example, X509Data can be hydrated into an X509Certificate, which can be used to validate the signature. In these cases it is important to validate the SigningKey that was used to validate the signature. This boolean only applies to default signing key validation. If [IssuerSigningKeyValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.issuersigningkeyvalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-issuersigningkeyvalidator) is set, it will be called regardless of whether this property is true or false. The default is false.
## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other