### PR TITLE
Merge Hotfixes from 2.3

### DIFF
--- a/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
@@ -25,6 +25,8 @@ namespace AzureIoTHub.Portal.Server
         internal const string OIDCValidateAudienceKey = "OIDC:ValidateAudience";
         internal const string OIDCValidateLifetimeKey = "OIDC:ValidateLifetime";
         internal const string OIDCValidateIssuerSigningKeyKey = "OIDC:ValidateIssuerSigningKey";
+        internal const string OIDCValidateActorKey = "OIDC:ValidateActor";
+        internal const string OIDCValidateTokenReplayKey = "OIDC:ValidateTokenReplay";
 
         internal const string IsLoRaFeatureEnabledKey = "LoRaFeature:Enabled";
 
@@ -78,6 +80,10 @@ namespace AzureIoTHub.Portal.Server
         internal abstract bool OIDCValidateLifetime { get; }
 
         internal abstract bool OIDCValidateIssuerSigningKey { get; }
+
+        internal abstract bool OIDCValidateActor { get; }
+
+        internal abstract bool OIDCValidateTokenReplay { get; }
 
         internal abstract bool IsLoRaEnabled { get; }
 

--- a/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
@@ -15,6 +15,7 @@ namespace AzureIoTHub.Portal.Server
         internal const string DPSConnectionStringKey = "IoTDPS:ConnectionString";
         internal const string DPSServiceEndpointKey = "IoTDPS:ServiceEndpoint";
         internal const string DPSIDScopeKey = "IoTDPS:IDScope";
+        internal const string UseSecurityHeadersKey = "UseSecurityHeaders";
 
         internal const string OIDCScopeKey = "OIDC:Scope";
         internal const string OIDCAuthorityKey = "OIDC:Authority";
@@ -62,6 +63,8 @@ namespace AzureIoTHub.Portal.Server
         internal abstract string DPSScopeID { get; }
 
         internal abstract string StorageAccountConnectionString { get; }
+
+        internal abstract bool UseSecurityHeaders { get; }
 
         internal abstract string OIDCScope { get; }
 

--- a/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ConfigHandler.cs
@@ -21,6 +21,10 @@ namespace AzureIoTHub.Portal.Server
         internal const string OIDCMetadataUrlKey = "OIDC:MetadataUrl";
         internal const string OIDCClientIdKey = "OIDC:ClientId";
         internal const string OIDCApiClientIdKey = "OIDC:ApiClientId";
+        internal const string OIDCValidateIssuerKey = "OIDC:ValidateIssuer";
+        internal const string OIDCValidateAudienceKey = "OIDC:ValidateAudience";
+        internal const string OIDCValidateLifetimeKey = "OIDC:ValidateLifetime";
+        internal const string OIDCValidateIssuerSigningKeyKey = "OIDC:ValidateIssuerSigningKey";
 
         internal const string IsLoRaFeatureEnabledKey = "LoRaFeature:Enabled";
 
@@ -66,6 +70,14 @@ namespace AzureIoTHub.Portal.Server
         internal abstract string OIDCMetadataUrl { get; }
 
         internal abstract string OIDCAuthority { get; }
+
+        internal abstract bool OIDCValidateIssuer { get; }
+
+        internal abstract bool OIDCValidateAudience { get; }
+
+        internal abstract bool OIDCValidateLifetime { get; }
+
+        internal abstract bool OIDCValidateIssuerSigningKey { get; }
 
         internal abstract bool IsLoRaEnabled { get; }
 

--- a/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
@@ -30,6 +30,8 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string StorageAccountConnectionString => this.config[StorageAccountConnectionStringKey];
 
+        internal override bool UseSecurityHeaders => this.config.GetValue(UseSecurityHeadersKey, true);
+
         internal override string OIDCScope => this.config[OIDCScopeKey];
 
         internal override string OIDCAuthority => this.config[OIDCAuthorityKey];

--- a/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
@@ -40,6 +40,14 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string OIDCApiClientId => this.config[OIDCApiClientIdKey];
 
+        internal override bool OIDCValidateIssuer => this.config.GetValue(OIDCValidateIssuerKey, true);
+
+        internal override bool OIDCValidateAudience => this.config.GetValue(OIDCValidateAudienceKey, true);
+
+        internal override bool OIDCValidateLifetime => this.config.GetValue(OIDCValidateLifetimeKey, true);
+
+        internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/DevelopmentConfigHandler.cs
@@ -48,6 +48,10 @@ namespace AzureIoTHub.Portal.Server
 
         internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
 
+        internal override bool OIDCValidateActor => this.config.GetValue(OIDCValidateActorKey, false);
+
+        internal override bool OIDCValidateTokenReplay => this.config.GetValue(OIDCValidateTokenReplayKey, false);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
@@ -40,6 +40,14 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string OIDCApiClientId => this.config[OIDCApiClientIdKey];
 
+        internal override bool OIDCValidateIssuer => this.config.GetValue(OIDCValidateIssuerKey, true);
+
+        internal override bool OIDCValidateAudience => this.config.GetValue(OIDCValidateAudienceKey, true);
+
+        internal override bool OIDCValidateLifetime => this.config.GetValue(OIDCValidateLifetimeKey, true);
+
+        internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
@@ -30,6 +30,8 @@ namespace AzureIoTHub.Portal.Server
 
         internal override string StorageAccountConnectionString => this.config.GetConnectionString(StorageAccountConnectionStringKey);
 
+        internal override bool UseSecurityHeaders => this.config.GetValue(UseSecurityHeadersKey, true);
+
         internal override string OIDCScope => this.config[OIDCScopeKey];
 
         internal override string OIDCAuthority => this.config[OIDCAuthorityKey];

--- a/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
+++ b/src/AzureIoTHub.Portal/Server/ProductionConfigHandler.cs
@@ -48,6 +48,10 @@ namespace AzureIoTHub.Portal.Server
 
         internal override bool OIDCValidateIssuerSigningKey => this.config.GetValue(OIDCValidateIssuerSigningKeyKey, true);
 
+        internal override bool OIDCValidateActor => this.config.GetValue(OIDCValidateActorKey, false);
+
+        internal override bool OIDCValidateTokenReplay => this.config.GetValue(OIDCValidateTokenReplayKey, false);
+
         internal override bool IsLoRaEnabled => bool.Parse(this.config[IsLoRaFeatureEnabledKey] ?? "true");
 
         internal override string StorageAccountBlobContainerName => this.config[StorageAccountBlobContainerNameKey];

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -279,7 +279,15 @@ namespace AzureIoTHub.Portal.Server
             _ = app.UseProblemDetails();
             app.UseIfElse(IsApiRequest, UseApiExceptionMiddleware, UseUIExceptionMiddleware);
 
-            _ = app.UseSecurityHeaders();
+            _ = app.UseSecurityHeaders(opts =>
+            {
+                _= opts.AddContentSecurityPolicy(csp =>
+                {
+                    _ = csp.AddFrameAncestors()
+                        .Self()
+                        .From(app.ApplicationServices.GetService<ConfigHandler>().OIDCMetadataUrl);
+                });
+            });
 
             if (env.IsDevelopment())
             {

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -87,10 +87,10 @@ namespace AzureIoTHub.Portal.Server
                     opts.MetadataAddress = configuration.OIDCMetadataUrl;
                     opts.Audience = configuration.OIDCApiClientId;
 
-                    opts.TokenValidationParameters.ValidateIssuer = true;
-                    opts.TokenValidationParameters.ValidateAudience = true;
-                    opts.TokenValidationParameters.ValidateLifetime = true;
-                    opts.TokenValidationParameters.ValidateIssuerSigningKey = true;
+                    opts.TokenValidationParameters.ValidateIssuer = configuration.OIDCValidateIssuer;
+                    opts.TokenValidationParameters.ValidateAudience = configuration.OIDCValidateAudience;
+                    opts.TokenValidationParameters.ValidateLifetime = configuration.OIDCValidateLifetime;
+                    opts.TokenValidationParameters.ValidateIssuerSigningKey = configuration.OIDCValidateIssuerSigningKey;
                 });
 
             _ = services.AddSingleton(configuration);

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -91,6 +91,8 @@ namespace AzureIoTHub.Portal.Server
                     opts.TokenValidationParameters.ValidateAudience = configuration.OIDCValidateAudience;
                     opts.TokenValidationParameters.ValidateLifetime = configuration.OIDCValidateLifetime;
                     opts.TokenValidationParameters.ValidateIssuerSigningKey = configuration.OIDCValidateIssuerSigningKey;
+                    opts.TokenValidationParameters.ValidateActor = configuration.OIDCValidateActor;
+                    opts.TokenValidationParameters.ValidateTokenReplay = configuration.OIDCValidateTokenReplay;
                 });
 
             _ = services.AddSingleton(configuration);

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -277,19 +277,24 @@ namespace AzureIoTHub.Portal.Server
             ArgumentNullException.ThrowIfNull(env, nameof(env));
             ArgumentNullException.ThrowIfNull(app, nameof(app));
 
+            var configuration = app.ApplicationServices.GetService<ConfigHandler>();
+
             // Use problem details
             _ = app.UseProblemDetails();
             app.UseIfElse(IsApiRequest, UseApiExceptionMiddleware, UseUIExceptionMiddleware);
 
-            _ = app.UseSecurityHeaders(opts =>
+            if (configuration.UseSecurityHeaders)
             {
-                _= opts.AddContentSecurityPolicy(csp =>
+                _ = app.UseSecurityHeaders(opts =>
                 {
-                    _ = csp.AddFrameAncestors()
-                        .Self()
-                        .From(app.ApplicationServices.GetService<ConfigHandler>().OIDCMetadataUrl);
+                    _ = opts.AddContentSecurityPolicy(csp =>
+                    {
+                        _ = csp.AddFrameAncestors()
+                            .Self()
+                            .From(configuration.OIDCMetadataUrl);
+                    });
                 });
-            });
+            }
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
## Description

What's new?

**New options are now present on the portal**
- OIDC__ValidateIssuer
  > Validation of the issuer mitigates forwarding attacks that can occur when an IdentityProvider represents multiple tenants and signs tokens with the same keys. It is possible that a token issued for the same audience could be from a different tenant. For example an application could accept users from contoso.onmicrosoft.com but not fabrikam.onmicrosoft.com, both valid tenants. An application that accepts tokens from fabrikam could forward them to the application that accepts tokens for contoso. This boolean only applies to default issuer validation. If [IssuerValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.issuervalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-issuervalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateAudience
  > Validation of the audience, mitigates forwarding attacks. For example, a site that receives a token, could not replay it to another side. A forwarded token would contain the audience of the original site. This boolean only applies to default audience validation. If [AudienceValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.audiencevalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-audiencevalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateLifetime
  > This boolean only applies to default lifetime validation. If [LifetimeValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.lifetimevalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-lifetimevalidator) is set, it will be called regardless of whether this property is true or false. The default is true.
- OIDC__ValidateIssuerSigningKey
  > It is possible for tokens to contain the public key needed to check the signature. For example, X509Data can be hydrated into an X509Certificate, which can be used to validate the signature. In these cases it is important to validate the SigningKey that was used to validate the signature. This boolean only applies to default signing key validation. If [IssuerSigningKeyValidator](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.issuersigningkeyvalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-issuersigningkeyvalidator) is set, it will be called regardless of whether this property is true or false. The default is false.
- OIDC_ValidateActor
  > If an actor token is detected, whether it should be validated. The default is false.
- OIDC_ValidateTokenReplay
  > This boolean only applies to default token replay validation. If [TokenReplayValidator](https://docs.microsoft.com/fr-fr/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.tokenreplayvalidator?view=azure-dotnet#microsoft-identitymodel-tokens-tokenvalidationparameters-tokenreplayvalidator) is set, it will be called regardless of whether this property is true or false. The default is false.

- UseSecurityHeaders
  > This boolean adds the following headers to all responses :
  > `X-Content-Type-Options: nosniff`
  > `Strict-Transport-Security: max-age=31536000; includeSubDomains` - _only applied to HTTPS responses_
  > `X-Frame-Options: Deny` - _only applied to text/html responses_
  > `X-XSS-Protection: 1; mode=block` - _only applied to text/html responses_
  > `Referrer-Policy: strict-origin-when-cross-origin `- _only applied to text/html responses_
  > `Content-Security-Policy: object-src 'none'; form-action 'self'; frame-ancestors 'none'` - _only applied to text/html responses_

**Fix CSP restrictions**

Add  **OIDC MetadataUrl** to authorized frame ancestors.

## What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other