### PR TITLE
Add the plugin mkdocs-swagger-ui-tag to remove "try it out" on swagger

### DIFF
--- a/docs/open-api.md
+++ b/docs/open-api.md
@@ -1,1 +1,1 @@
-!!swagger swagger.json!!
+<swagger-ui src="./swagger.json"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,9 @@ plugins:
   - search:
       lang: en
   - macros
-  - render_swagger
+  - swagger-ui-tag:
+      supportedSubmitMethods: []
+      filter: true
 
 # Navigation
 nav:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs-material==8.3.9
 mkdocs-macros-plugin==0.7.0
-mkdocs-render-swagger-plugin==0.0.3
+mkdocs-swagger-ui-tag==0.4.0


### PR DESCRIPTION
## Description

What's new?

- Usage of the plugin [mkdocs-swagger-ui-tag](https://github.com/blueswen/mkdocs-swagger-ui-tag) to:
  - Remove Try It Out on swagger ui
  -  Handle dark mode when rendering swagger ui
  - Enable filtering tagged operations

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other