### PR TITLE
Feature/1211 migrate device models from st table to database

### DIFF
--- a/src/AzureIoTHub.Portal.Infrastructure/Migrations/20220911161906_Add DeviceModel.Designer.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Migrations/20220911161906_Add DeviceModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AzureIoTHub.Portal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AzureIoTHub.Portal.Infrastructure.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220911161906_Add DeviceModel")]
+    partial class AddDeviceModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -75,33 +77,6 @@ namespace AzureIoTHub.Portal.Infrastructure.Migrations
                     b.ToTable("DeviceModels");
                 });
 
-            modelBuilder.Entity("AzureIoTHub.Portal.Domain.Entities.DeviceModelCommand", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("text");
-
-                    b.Property<bool>("Confirmed")
-                        .HasColumnType("boolean");
-
-                    b.Property<string>("DeviceModelId")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Frame")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<bool>("IsBuiltin")
-                        .HasColumnType("boolean");
-
-                    b.Property<int>("Port")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("DeviceModelCommands");
-                });
-
             modelBuilder.Entity("AzureIoTHub.Portal.Domain.Entities.DeviceModelProperty", b =>
                 {
                     b.Property<string>("Id")
@@ -131,26 +106,6 @@ namespace AzureIoTHub.Portal.Infrastructure.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("DeviceModelProperties");
-                });
-
-            modelBuilder.Entity("AzureIoTHub.Portal.Domain.Entities.DeviceTag", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Label")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<bool>("Required")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool>("Searchable")
-                        .HasColumnType("boolean");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("DeviceTags");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/AzureIoTHub.Portal.Infrastructure/Migrations/20220911161906_Add DeviceModel.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Migrations/20220911161906_Add DeviceModel.cs
@@ -1,0 +1,45 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable disable
+
+namespace AzureIoTHub.Portal.Infrastructure.Migrations
+{
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    public partial class AddDeviceModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            _ = migrationBuilder.CreateTable(
+                name: "DeviceModels",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    IsBuiltin = table.Column<bool>(type: "boolean", nullable: false),
+                    SupportLoRaFeatures = table.Column<bool>(type: "boolean", nullable: false),
+                    UseOTAA = table.Column<bool>(type: "boolean", nullable: true),
+                    PreferredWindow = table.Column<int>(type: "integer", nullable: true),
+                    Deduplication = table.Column<int>(type: "integer", nullable: true),
+                    ABPRelaxMode = table.Column<bool>(type: "boolean", nullable: true),
+                    Downlink = table.Column<bool>(type: "boolean", nullable: true),
+                    KeepAliveTimeout = table.Column<int>(type: "integer", nullable: true),
+                    RXDelay = table.Column<int>(type: "integer", nullable: true),
+                    SensorDecoder = table.Column<string>(type: "text", nullable: true),
+                    AppEUI = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    _ = table.PrimaryKey("PK_DeviceModels", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            _ = migrationBuilder.DropTable(
+                name: "DeviceModels");
+        }
+    }
+}

--- a/src/AzureIoTHub.Portal.Infrastructure/PortalDbContext.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/PortalDbContext.cs
@@ -15,6 +15,7 @@ namespace AzureIoTHub.Portal.Infrastructure
         public DbSet<DeviceModelProperty> DeviceModelProperties { get; set; }
         public DbSet<DeviceTag> DeviceTags { get; set; }
         public DbSet<DeviceModelCommand> DeviceModelCommands { get; set; }
+        public DbSet<DeviceModel> DeviceModels { get; set; }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public PortalDbContext(DbContextOptions<PortalDbContext> options)

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelSeeder.cs
@@ -1,0 +1,54 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Infrastructure.Seeds
+{
+    using Azure.Data.Tables;
+    using Domain;
+    using Domain.Entities;
+    using Factories;
+    using Microsoft.EntityFrameworkCore;
+    using Models.v10.LoRaWAN;
+
+    internal static class DeviceModelSeeder
+    {
+        public static async Task MigrateDeviceModels(this PortalDbContext ctx, ConfigHandler config)
+        {
+            var table = new TableClientFactory(config.StorageAccountConnectionString)
+                                .GetDeviceTemplates();
+
+            var set = ctx.Set<DeviceModel>();
+
+            foreach (var item in table.Query<TableEntity>().ToArray())
+            {
+                if (await set.AnyAsync(c => c.Id == item.RowKey))
+                    continue;
+
+#pragma warning disable CS8629 // Nullable value type may be null.
+                _ = await set.AddAsync(new DeviceModel
+                {
+                    Id = item.RowKey,
+                    Name = item[nameof(DeviceModel.Name)]?.ToString(),
+                    Description = item[nameof(DeviceModel.Description)]?.ToString(),
+                    IsBuiltin = bool.Parse(item[nameof(DeviceModel.IsBuiltin)]?.ToString() ?? "false"),
+                    SupportLoRaFeatures = bool.Parse(item[nameof(DeviceModel.SupportLoRaFeatures)]?.ToString() ?? "false"),
+                    ABPRelaxMode = bool.TryParse(item[nameof(DeviceModel.ABPRelaxMode)]?.ToString(), out var abpRelaxMode) ? abpRelaxMode : null,
+                    Deduplication = Enum.TryParse<DeduplicationMode>(item[nameof(DeviceModel.Deduplication)]?.ToString(), out var deduplication) ? deduplication : null,
+                    Downlink = bool.TryParse(item[nameof(DeviceModel.Downlink)]?.ToString(), out var downLink) ? downLink : null,
+                    KeepAliveTimeout = int.TryParse(item[nameof(DeviceModel.KeepAliveTimeout)]?.ToString(), out var keepAliveTimeout) ? keepAliveTimeout : null,
+                    PreferredWindow = int.TryParse(item[nameof(DeviceModel.PreferredWindow)]?.ToString(), out var preferredWindow) ? preferredWindow : null,
+                    RXDelay = int.TryParse(item[nameof(DeviceModel.PreferredWindow)]?.ToString(), out var rxDelay) ? rxDelay : null,
+                    UseOTAA = bool.TryParse(item[nameof(DeviceModel.UseOTAA)]?.ToString(), out var useOTAA) ? useOTAA : null,
+                    AppEUI = item[nameof(DeviceModel.AppEUI)]?.ToString(),
+                    SensorDecoder = item[nameof(DeviceModel.SensorDecoder)]?.ToString()
+                });
+#pragma warning restore CS8629 // Nullable value type may be null.
+
+                if (config is ProductionConfigHandler)
+                {
+                    _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
+                }
+            }
+        }
+    }
+}

--- a/src/AzureIoTHub.Portal/Server/Startup.cs
+++ b/src/AzureIoTHub.Portal/Server/Startup.cs
@@ -465,6 +465,9 @@ namespace AzureIoTHub.Portal.Server
                 await context
                     .MigrateDeviceModelCommands(config);
 
+                await context
+                    .MigrateDeviceModels(config);
+
                 _ = await context.SaveChangesAsync();
             }
             catch (InvalidOperationException e)

--- a/src/AzureIoTHubPortal.Domain/Entities/DeviceModel.cs
+++ b/src/AzureIoTHubPortal.Domain/Entities/DeviceModel.cs
@@ -1,0 +1,37 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Domain.Entities
+{
+    using AzureIoTHub.Portal.Models.v10.LoRaWAN;
+    using Base;
+
+    public class DeviceModel : EntityBase
+    {
+        public string Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public bool IsBuiltin { get; set; }
+
+        public bool SupportLoRaFeatures { get; set; }
+
+        public bool? UseOTAA { get; set; }
+
+        public int? PreferredWindow { get; set; }
+
+        public DeduplicationMode? Deduplication { get; set; }
+
+        public bool? ABPRelaxMode { get; set; }
+
+        public bool? Downlink { get; set; }
+
+        public int? KeepAliveTimeout { get; set; }
+
+        public int? RXDelay { get; set; }
+
+        public string? SensorDecoder { get; set; }
+
+        public string? AppEUI { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

What's new?

- Fix #1211 

**Remark :** The column `SensorDecoderURL`in table `DeviceTemplates` won't be migrated. It is no more used by Portal and replaced by the column `SensorDecoder`

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other