### PR TITLE
Set default PostgreSQL image version to 14

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   database:
-    image: postgres
+    image: postgres:14-alpine
     restart: always
     environment:
       POSTGRES_PASSWORD: postgrePassword


### PR DESCRIPTION
## Description

What's new?

- Set default PostgreSQL image version to 14 to prevent Docker conflicts

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other