### PR TITLE
Add missing step docker/metadata-action on arm_templates job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,10 +107,17 @@ jobs:
             cp -r ../iotedge-lorawan-starterkit/TemplateBicep/* ./templates/iotedge-lorawan-starterkit/
             sed -r -i 's/..\/iotedge-lorawan-starterkit\/TemplateBicep\/main.bicep/.\/iotedge-lorawan-starterkit\/main.bicep/g' ./templates/azuredeploy.bicep
       
+      - name: Get semver
+        id: version
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.registry_name }}/${{ github.repository_owner }}/${{ env.image_name }}
+
       - name: Update IoTHub Portal docker image tag in app_service.bicep
         working-directory: arm-templates/templates
         env:
-          RELEASE_SEM_VERSION: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          RELEASE_SEM_VERSION: ${{ fromJSON(steps.version.outputs.json).labels['org.opencontainers.image.version'] }}
         run: sed -i 's/ghcr.io\/cgi-fr\/iothub-portal:latest/ghcr.io\/cgi-fr\/iothub-portal:${RELEASE_SEM_VERSION}/g' app_service.bicep
       
       - name: Generate ARM file


### PR DESCRIPTION
## Description

What's new?

- Add missing step docker/metadata-action on arm_templates job, required by the step `Update IoTHub Portal docker image tag in app_service.bicep`

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other