### PR TITLE
Remove Team reviewers to automated PR when API documentation updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
           token: ${{ steps.generate_app_token.outputs.token }}
           title: 'Update API documentation'
           labels: 'documentation'
-          team-reviewers: '@CGI-FR/azure-iot-portal-authors'
           body: | 
             Automated changes to the Open API documentation.
             This PR is related to the change **${{ github.event.head_commit.message }}** merged in **${{ github.event.head_commit.id }}**.


### PR DESCRIPTION
## Description

What's new?

- Remove Team Reviewers in github action that push the PR for a API documentation update.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other