### PR TITLE
Process LoRa Message only if comming from a device and can be deserialized

### DIFF
--- a/src/AzureIoTHub.Portal.Infrastructure/ConnectionAuthMethod.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ConnectionAuthMethod.cs
@@ -1,0 +1,28 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Infrastructure
+{
+    internal class ConnectionAuthMethod
+    {
+        internal enum ConnectionAuthScope
+        {
+            Hub,
+            Device,
+            Module
+        }
+
+        internal enum ConnectionAuthType
+        {
+            Symkey,
+            Sas,
+            X509
+        }
+
+        public ConnectionAuthScope Scope { get; set; }
+
+        public ConnectionAuthType Type { get; set; }
+
+        public string Issuer { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

What's new?

- Fix error in logs when trying to deserialize an event that is not coming from a LoRa device.

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other