### PR TITLE
Fix E2E startup when db provider not provided

### DIFF
--- a/src/AzureIoTHub.Portal.Infrastructure/Startup/IServiceCollectionExtension.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Startup/IServiceCollectionExtension.cs
@@ -133,7 +133,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Startup
                     _ = dbContextOptions.UseMySql(configuration.MySQLConnectionString, DatabaseHelper.GetMySqlServerVersion(configuration.MySQLConnectionString), x => x.MigrationsAssembly("AzureIoTHub.Portal.MySql"));
                     break;
                 default:
-                    return services;
+                    throw new InvalidOperationException($"'{configuration.DbProvider}' is not valid for the {ConfigHandlerBase.DbProviderKey} option. Please specify one of the valid values ({DbProviders.MySQL},{DbProviders.PostgreSQL}).");
             }
 
             _ = services.AddScoped<IUnitOfWork, UnitOfWork<PortalDbContext>>();


### PR DESCRIPTION
## Description

What's new?

- Fix Startup. Throw an exception if the db provider is not providing a valid value.

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other