### PR TITLE
#1793 Add AmazonIoTClient and AmazonIotDataClient configurations

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -111,6 +111,8 @@ jobs:
         IOTHUB__EVENTHUB__ENDPOINT: ${{ secrets.IOTHUB__EVENTHUB__ENDPOINT }}
         LORAKEYMANAGEMENT__CODE: ${{ secrets.LORAKEYMANAGEMENT__CODE }}
         IDEAS__AUTHENTICATION__TOKEN: ${{ secrets.IDEAS__AUTHENTICATION__TOKEN }}
+        
+        CLOUDPROVIDER: Azure
 
     - name: Wait until portal is up
       run: |

--- a/src/AzureIoTHub.Portal.Domain/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Domain/ConfigHandler.cs
@@ -74,6 +74,7 @@ namespace AzureIoTHub.Portal.Domain
         public abstract string MySQLConnectionString { get; }
 
         public abstract string DbProvider { get; }
+        public abstract string CloudProvider { get; }
         public abstract string AWSAccess { get; }
         public abstract string AWSAccessSecret { get; }
         public abstract string AWSRegion { get; }

--- a/src/AzureIoTHub.Portal.Domain/Shared/Constants/CloudProviders.cs
+++ b/src/AzureIoTHub.Portal.Domain/Shared/Constants/CloudProviders.cs
@@ -1,0 +1,13 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Domain.Shared.Constants
+{
+
+    public static class CloudProviders
+    {
+        public const string Azure = "Azure";
+
+        public const string AWS = "AWS";
+    }
+}

--- a/src/AzureIoTHub.Portal.Infrastructure/ConfigHandlerBase.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ConfigHandlerBase.cs
@@ -50,6 +50,8 @@ namespace AzureIoTHub.Portal.Infrastructure
         internal const string IdeasAuthenticationHeaderKey = "Ideas:Authentication:Header";
         internal const string IdeasAuthenticationTokenKey = "Ideas:Authentication:Token";
 
+        internal const string CloudProviderKey = "CloudProvider";
+
         internal const string AWSAccessKey = "AWS:Access";
         internal const string AWSAccessSecretKey = "AWS:AccessSecret";
         internal const string AWSRegionKey = "AWS:Region";

--- a/src/AzureIoTHub.Portal.Infrastructure/DevelopmentConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/DevelopmentConfigHandler.cs
@@ -82,6 +82,8 @@ namespace AzureIoTHub.Portal.Infrastructure
 
         public override string DbProvider => this.config.GetValue(DbProviderKey, DbProviders.PostgreSQL);
 
+        public override string CloudProvider => this.config[CloudProviderKey];
+
         public override string AWSAccess => this.config[AWSAccessKey];
         public override string AWSAccessSecret => this.config[AWSAccessSecretKey];
         public override string AWSRegion => this.config[AWSRegionKey];

--- a/src/AzureIoTHub.Portal.Infrastructure/ProductionConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ProductionConfigHandler.cs
@@ -82,6 +82,8 @@ namespace AzureIoTHub.Portal.Infrastructure
         public override string IdeasAuthenticationHeader => this.config.GetValue(IdeasAuthenticationHeaderKey, "Ocp-Apim-Subscription-Key");
         public override string IdeasAuthenticationToken => this.config.GetValue(IdeasAuthenticationTokenKey, string.Empty);
 
+        public override string CloudProvider => this.config[CloudProviderKey];
+
         public override string AWSAccess => this.config[AWSAccessKey];
         public override string AWSAccessSecret => this.config[AWSAccessSecretKey];
         public override string AWSRegion => this.config[AWSRegionKey];

--- a/src/AzureIoTHub.Portal.Server/AzureIoTHub.Portal.Server.csproj
+++ b/src/AzureIoTHub.Portal.Server/AzureIoTHub.Portal.Server.csproj
@@ -35,6 +35,8 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="AWSSDK.IoT" Version="3.7.105.14" />
+    <PackageReference Include="AWSSDK.IotData" Version="3.7.101.74" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.8.1" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.8.1" />

--- a/src/AzureIoTHub.Portal.Server/Startup.cs
+++ b/src/AzureIoTHub.Portal.Server/Startup.cs
@@ -82,10 +82,10 @@ namespace AzureIoTHub.Portal.Server
 
             if (configuration.CloudProvider.Equals(CloudProviders.AWS, StringComparison.Ordinal))
             {
-_ = services.AddSingleton(() => new AmazonIoTClient(configuration.AWSAccess, configuration.AWSAccessSecret, RegionEndpoint.GetBySystemName(configuration.AWSRegion)));
+                _ = services.AddSingleton(() => new AmazonIoTClient(configuration.AWSAccess, configuration.AWSAccessSecret, RegionEndpoint.GetBySystemName(configuration.AWSRegion)));
                 _ = services.AddSingleton(async sp =>
                 {
-                    var endpoint = await sp.GetService<AmazonIoTClient>().DescribeEndpointAsync(new DescribeEndpointRequest
+                    var endpoint = await sp.GetService<AmazonIoTClient>().DescribeEndpointAsync(new Amazon.IoT.Model.DescribeEndpointRequest
                     {
                         EndpointType = "iot:Data-ATS"
                     });

--- a/src/AzureIoTHub.Portal.Server/Startup.cs
+++ b/src/AzureIoTHub.Portal.Server/Startup.cs
@@ -80,7 +80,7 @@ namespace AzureIoTHub.Portal.Server
             _ = services.AddSingleton(new PortalMetric());
             _ = services.AddSingleton(new LoRaGatewayIDList());
 
-            if (configuration.CloudProvider.Equals(CloudProviders.AWS))
+            if (configuration.CloudProvider.Equals(CloudProviders.AWS, StringComparison.Ordinal))
             {
                 var AWSIoTClient = new AmazonIoTClient(configuration.AWSAccess, configuration.AWSAccessSecret, RegionEndpoint.GetBySystemName(configuration.AWSRegion));
                 var endPoint = AWSIoTClient.DescribeEndpointAsync(new Amazon.IoT.Model.DescribeEndpointRequest

--- a/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/DevelopmentConfigHandlerTests.cs
+++ b/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/DevelopmentConfigHandlerTests.cs
@@ -51,6 +51,7 @@ namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
         [TestCase(ConfigHandlerBase.AWSAccessKey, nameof(ConfigHandlerBase.AWSAccess))]
         [TestCase(ConfigHandlerBase.AWSAccessSecretKey, nameof(ConfigHandlerBase.AWSAccessSecret))]
         [TestCase(ConfigHandlerBase.AWSRegionKey, nameof(ConfigHandlerBase.AWSRegion))]
+        [TestCase(ConfigHandlerBase.CloudProviderKey, nameof(ConfigHandlerBase.CloudProvider))]
         public void SettingsShouldGetValueFromAppSettings(string configKey, string configPropertyName)
         {
             // Arrange

--- a/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ProductionConfigHandlerTests.cs
+++ b/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ProductionConfigHandlerTests.cs
@@ -76,6 +76,7 @@ namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
         [TestCase(ConfigHandlerBase.AWSAccessKey, nameof(ConfigHandlerBase.AWSAccess))]
         [TestCase(ConfigHandlerBase.AWSAccessSecretKey, nameof(ConfigHandlerBase.AWSAccessSecret))]
         [TestCase(ConfigHandlerBase.AWSRegionKey, nameof(ConfigHandlerBase.AWSRegion))]
+        [TestCase(ConfigHandlerBase.CloudProviderKey, nameof(ConfigHandlerBase.CloudProvider))]
         public void SettingsShouldGetValueFromAppSettings(string configKey, string configPropertyName)
         {
             // Arrange

--- a/src/e2e-docker-compose.yml
+++ b/src/e2e-docker-compose.yml
@@ -46,6 +46,7 @@ services:
       IoTHub__EventHub__Endpoint: "${IOTHUB__EVENTHUB__ENDPOINT}"
       LoRaKeyManagement__Code: "${LORAKEYMANAGEMENT__CODE}"
       Ideas__Authentication__Token: "${IDEAS__AUTHENTICATION__TOKEN}"
+      CloudProvider: "${CLOUDPROVIDER}"
     depends_on:
       - "database"
     ports:


### PR DESCRIPTION
- Add "CloudProvider" in configuration
- Add AmazonIoTClient and AmazonIotDataClient configurations when CloudProvider is AWS


## Description

What's new?

- Fix #1793

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other