### PR TITLE
#1925 & #1928 Specific config handler and throw error if no CloudProvider

### DIFF
--- a/src/AzureIoTHub.Portal.Domain/ConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Domain/ConfigHandler.cs
@@ -78,5 +78,6 @@ namespace AzureIoTHub.Portal.Domain
         public abstract string AWSAccess { get; }
         public abstract string AWSAccessSecret { get; }
         public abstract string AWSRegion { get; }
+        public abstract string AWSS3StorageConnectionString { get; }
     }
 }

--- a/src/AzureIoTHub.Portal.Domain/Exceptions/InvalidCloudProviderException.cs
+++ b/src/AzureIoTHub.Portal.Domain/Exceptions/InvalidCloudProviderException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Domain.Exceptions
+{
+    using System;
+    using AzureIoTHub.Portal.Domain.Shared.Constants;
+
+    public class InvalidCloudProviderException : BaseException
+    {
+        public InvalidCloudProviderException(string detail, Exception? innerException = null) : base(ErrorTitles.InvalidCloudProvider, detail, innerException)
+        {
+        }
+    }
+}

--- a/src/AzureIoTHub.Portal.Domain/Shared/Constants/ErrorTitles.cs
+++ b/src/AzureIoTHub.Portal.Domain/Shared/Constants/ErrorTitles.cs
@@ -10,5 +10,11 @@ namespace AzureIoTHub.Portal.Domain.Shared.Constants
         public const string ResourceNotFound = "Resource Not Found";
 
         public const string ResourceAlreadyExists = "Resource Already Exists";
+
+        public const string InvalidCloudProvider = "Invalid Cloud Provider";
+
+        public const string InvalidCloudProviderUndefined = "The CloudProvider configuration is undefined";
+
+        public const string InvalidCloudProviderIncorrect = "The CloudProvider configuration is incorrect";
     }
 }

--- a/src/AzureIoTHub.Portal.Infrastructure/ConfigHandlerBase.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ConfigHandlerBase.cs
@@ -55,5 +55,6 @@ namespace AzureIoTHub.Portal.Infrastructure
         internal const string AWSAccessKey = "AWS:Access";
         internal const string AWSAccessSecretKey = "AWS:AccessSecret";
         internal const string AWSRegionKey = "AWS:Region";
+        internal const string AWSS3StorageConnectionStringKey = "AWS:S3Storage:ConnectionString";
     }
 }

--- a/src/AzureIoTHub.Portal.Infrastructure/ProductionAWSConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ProductionAWSConfigHandler.cs
@@ -6,11 +6,11 @@ namespace AzureIoTHub.Portal.Infrastructure
     using AzureIoTHub.Portal.Domain.Shared.Constants;
     using Microsoft.Extensions.Configuration;
 
-    internal class DevelopmentConfigHandler : ConfigHandlerBase
+    internal class ProductionAWSConfigHandler : ConfigHandlerBase
     {
         private readonly IConfiguration config;
 
-        internal DevelopmentConfigHandler(IConfiguration config)
+        internal ProductionAWSConfigHandler(IConfiguration config)
         {
             this.config = config;
         }
@@ -35,9 +35,9 @@ namespace AzureIoTHub.Portal.Infrastructure
 
         public override string DPSScopeID => this.config[DPSIDScopeKey]!;
 
-        public override string StorageAccountConnectionString => this.config[StorageAccountConnectionStringKey]!;
+        public override string StorageAccountConnectionString => throw new NotImplementedException();
 
-        public override int StorageAccountDeviceModelImageMaxAge => this.config.GetValue(StorageAccountDeviceModelImageMaxAgeKey, 86400);
+        public override int StorageAccountDeviceModelImageMaxAge => throw new NotImplementedException();
 
         public override bool UseSecurityHeaders => this.config.GetValue(UseSecurityHeadersKey, true);
 

--- a/src/AzureIoTHub.Portal.Infrastructure/ProductionAzureConfigHandler.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/ProductionAzureConfigHandler.cs
@@ -6,11 +6,11 @@ namespace AzureIoTHub.Portal.Infrastructure
     using AzureIoTHub.Portal.Domain.Shared.Constants;
     using Microsoft.Extensions.Configuration;
 
-    internal class ProductionConfigHandler : ConfigHandlerBase
+    internal class ProductionAzureConfigHandler : ConfigHandlerBase
     {
         private readonly IConfiguration config;
 
-        internal ProductionConfigHandler(IConfiguration config)
+        internal ProductionAzureConfigHandler(IConfiguration config)
         {
             this.config = config;
         }
@@ -84,8 +84,11 @@ namespace AzureIoTHub.Portal.Infrastructure
 
         public override string CloudProvider => this.config[CloudProviderKey];
 
-        public override string AWSAccess => this.config[AWSAccessKey];
-        public override string AWSAccessSecret => this.config[AWSAccessSecretKey];
-        public override string AWSRegion => this.config[AWSRegionKey];
+        public override string AWSAccess => throw new NotImplementedException();
+
+        public override string AWSAccessSecret => throw new NotImplementedException();
+
+        public override string AWSRegion => throw new NotImplementedException();
+        public override string AWSS3StorageConnectionString => throw new NotImplementedException();
     }
 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelCommandSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelCommandSeeder.cs
@@ -36,7 +36,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelPropertySeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelPropertySeeder.cs
@@ -36,7 +36,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceModelSeeder.cs
@@ -44,7 +44,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceTagSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/DeviceTagSeeder.cs
@@ -33,7 +33,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/EdgeDeviceModelCommandSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/EdgeDeviceModelCommandSeeder.cs
@@ -33,7 +33,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Infrastructure/Seeds/EdgeDeviceModelSeeder.cs
+++ b/src/AzureIoTHub.Portal.Infrastructure/Seeds/EdgeDeviceModelSeeder.cs
@@ -32,7 +32,7 @@ namespace AzureIoTHub.Portal.Infrastructure.Seeds
                 });
 #pragma warning restore CS8629 // Nullable value type may be null.
 
-                if (config is ProductionConfigHandler)
+                if (config is ProductionAzureConfigHandler)
                 {
                     _ = await table.DeleteEntityAsync(item.PartitionKey, item.RowKey);
                 }

--- a/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ConfigHandlerFactoryTest.cs
+++ b/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ConfigHandlerFactoryTest.cs
@@ -3,7 +3,10 @@
 
 namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
 {
+    using AzureIoTHub.Portal.Domain.Exceptions;
+    using AzureIoTHub.Portal.Domain.Shared.Constants;
     using AzureIoTHub.Portal.Infrastructure;
+    using FluentAssertions;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Hosting;
     using Moq;
@@ -31,6 +34,8 @@ namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
             // Arrange
             _ = this.mockHostEnvironment.Setup(c => c.EnvironmentName)
                 .Returns(Environments.Development);
+            _ = this.mockConfiguration.Setup(cnf => cnf[ConfigHandlerBase.CloudProviderKey])
+                    .Returns(CloudProviders.Azure);
 
             // Act
             var result = ConfigHandlerFactory.Create(this.mockHostEnvironment.Object, this.mockConfiguration.Object);
@@ -41,17 +46,67 @@ namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
 
 
         [Test]
-        public void WhenUsingProdEnvironmentShouldReturnProductionConfigHandler()
+        public void WhenUsingProdAzureEnvironmentShouldReturnProductionAzureConfigHandler()
         {
             // Arrange
             _ = this.mockHostEnvironment.Setup(c => c.EnvironmentName)
                     .Returns(Environments.Production);
+            _ = this.mockConfiguration.Setup(cnf => cnf[ConfigHandlerBase.CloudProviderKey])
+                    .Returns(CloudProviders.Azure);
 
             // Act
             var result = ConfigHandlerFactory.Create(this.mockHostEnvironment.Object, this.mockConfiguration.Object);
 
             // Assert
-            Assert.IsAssignableFrom<ProductionConfigHandler>(result);
+            Assert.IsAssignableFrom<ProductionAzureConfigHandler>(result);
+        }
+
+        [Test]
+        public void WhenUsingProdAWSEnvironmentShouldReturnProductionAWSConfigHandler()
+        {
+            // Arrange
+            _ = this.mockHostEnvironment.Setup(c => c.EnvironmentName)
+                    .Returns(Environments.Production);
+            _ = this.mockConfiguration.Setup(cnf => cnf[ConfigHandlerBase.CloudProviderKey])
+                    .Returns(CloudProviders.AWS);
+
+            // Act
+            var result = ConfigHandlerFactory.Create(this.mockHostEnvironment.Object, this.mockConfiguration.Object);
+
+            // Assert
+            Assert.IsAssignableFrom<ProductionAWSConfigHandler>(result);
+        }
+
+        [Test]
+        public void WhenNoConfigCloudProviderShouldThrowInvalidCloudProviderException()
+        {
+            // Arrange
+            _ = this.mockHostEnvironment.Setup(c => c.EnvironmentName)
+                    .Returns(Environments.Production);
+            _ = this.mockConfiguration.Setup(cnf => cnf[ConfigHandlerBase.CloudProviderKey])
+                    .Returns((string)null);
+
+            // Act
+            var result = () => ConfigHandlerFactory.Create(this.mockHostEnvironment.Object, this.mockConfiguration.Object);
+
+            // Assert
+            _ = result.Should().Throw<InvalidCloudProviderException>().WithMessage(ErrorTitles.InvalidCloudProviderUndefined);
+        }
+
+        [Test]
+        public void WhenWrongCloudProviderShouldThrowInvalidCloudProviderException()
+        {
+            // Arrange
+            _ = this.mockHostEnvironment.Setup(c => c.EnvironmentName)
+                    .Returns(Environments.Production);
+            _ = this.mockConfiguration.Setup(cnf => cnf[ConfigHandlerBase.CloudProviderKey])
+                    .Returns("Test");
+
+            // Act
+            var result = () => ConfigHandlerFactory.Create(this.mockHostEnvironment.Object, this.mockConfiguration.Object);
+
+            // Assert
+            _ = result.Should().Throw<InvalidCloudProviderException>().WithMessage(ErrorTitles.InvalidCloudProviderIncorrect);
         }
     }
 }

--- a/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ProductionAWSConfigHandlerTests.cs
+++ b/src/AzureIoTHub.Portal.Tests.Unit/Infrastructure/ProductionAWSConfigHandlerTests.cs
@@ -1,0 +1,285 @@
+// Copyright (c) CGI France. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureIoTHub.Portal.Tests.Unit.Infrastructure
+{
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using AzureIoTHub.Portal.Domain.Shared.Constants;
+    using AzureIoTHub.Portal.Infrastructure;
+    using FluentAssertions;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ProductionAWSConfigHandlerTests
+    {
+        private MockRepository mockRepository;
+
+        private Mock<IConfiguration> mockConfiguration;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.mockRepository = new MockRepository(MockBehavior.Strict);
+
+            this.mockConfiguration = this.mockRepository.Create<IConfiguration>();
+        }
+
+        private ProductionAWSConfigHandler CreateProductionAWSConfigHandler()
+        {
+            return new ProductionAWSConfigHandler(this.mockConfiguration.Object);
+        }
+
+        [TestCase(ConfigHandlerBase.PortalNameKey, nameof(ConfigHandlerBase.PortalName))]
+        [TestCase(ConfigHandlerBase.DPSServiceEndpointKey, nameof(ConfigHandlerBase.DPSEndpoint))]
+        [TestCase(ConfigHandlerBase.DPSIDScopeKey, nameof(ConfigHandlerBase.DPSScopeID))]
+        [TestCase(ConfigHandlerBase.OIDCScopeKey, nameof(ConfigHandlerBase.OIDCScope))]
+        [TestCase(ConfigHandlerBase.OIDCAuthorityKey, nameof(ConfigHandlerBase.OIDCAuthority))]
+        [TestCase(ConfigHandlerBase.OIDCMetadataUrlKey, nameof(ConfigHandlerBase.OIDCMetadataUrl))]
+        [TestCase(ConfigHandlerBase.OIDCClientIdKey, nameof(ConfigHandlerBase.OIDCClientId))]
+        [TestCase(ConfigHandlerBase.OIDCApiClientIdKey, nameof(ConfigHandlerBase.OIDCApiClientId))]
+        [TestCase(ConfigHandlerBase.LoRaKeyManagementUrlKey, nameof(ConfigHandlerBase.LoRaKeyManagementUrl))]
+        [TestCase(ConfigHandlerBase.LoRaKeyManagementCodeKey, nameof(ConfigHandlerBase.LoRaKeyManagementCode))]
+        [TestCase(ConfigHandlerBase.LoRaKeyManagementApiVersionKey, nameof(ConfigHandlerBase.LoRaKeyManagementApiVersion))]
+        [TestCase(ConfigHandlerBase.IoTHubConnectionStringKey, nameof(ConfigHandlerBase.IoTHubConnectionString))]
+        [TestCase(ConfigHandlerBase.DPSConnectionStringKey, nameof(ConfigHandlerBase.DPSConnectionString))]
+        [TestCase(ConfigHandlerBase.PostgreSQLConnectionStringKey, nameof(ConfigHandlerBase.PostgreSQLConnectionString))]
+        [TestCase(ConfigHandlerBase.MySQLConnectionStringKey, nameof(ConfigHandlerBase.MySQLConnectionString))]
+        [TestCase(ConfigHandlerBase.AWSAccessKey, nameof(ConfigHandlerBase.AWSAccess))]
+        [TestCase(ConfigHandlerBase.AWSAccessSecretKey, nameof(ConfigHandlerBase.AWSAccessSecret))]
+        [TestCase(ConfigHandlerBase.AWSRegionKey, nameof(ConfigHandlerBase.AWSRegion))]
+        [TestCase(ConfigHandlerBase.AWSS3StorageConnectionStringKey, nameof(ConfigHandlerBase.AWSS3StorageConnectionString))]
+        [TestCase(ConfigHandlerBase.CloudProviderKey, nameof(ConfigHandlerBase.CloudProvider))]
+        public void SettingsShouldGetValueFromAppSettings(string configKey, string configPropertyName)
+        {
+            // Arrange
+            var expected = Guid.NewGuid().ToString();
+            var configHandler = CreateProductionAWSConfigHandler();
+
+            _ = this.mockConfiguration.SetupGet(c => c[It.Is<string>(x => x == configKey)])
+                .Returns(expected);
+
+            // Act
+            var result = configHandler
+                                .GetType()
+                                .GetProperty(configPropertyName)
+                                .GetValue(configHandler, null);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [TestCase(nameof(ConfigHandlerBase.StorageAccountConnectionString))]
+        [TestCase(nameof(ConfigHandlerBase.StorageAccountDeviceModelImageMaxAge))]
+        public void SettingsShouldThrowError(string configPropertyName)
+        {
+            // Arrange
+            var productionConfigHandler = CreateProductionAWSConfigHandler();
+
+            // Act
+            var result = () => productionConfigHandler.GetType().GetProperty(configPropertyName).GetValue(productionConfigHandler, null);
+
+            // Assert
+            _ = result.Should().Throw<TargetInvocationException>();
+
+            this.mockRepository.VerifyAll();
+        }
+
+        [TestCase(ConfigHandlerBase.OIDCValidateAudienceKey, nameof(ConfigHandlerBase.OIDCValidateAudience))]
+        [TestCase(ConfigHandlerBase.OIDCValidateIssuerKey, nameof(ConfigHandlerBase.OIDCValidateIssuer))]
+        [TestCase(ConfigHandlerBase.OIDCValidateIssuerSigningKeyKey, nameof(ConfigHandlerBase.OIDCValidateIssuerSigningKey))]
+        [TestCase(ConfigHandlerBase.OIDCValidateLifetimeKey, nameof(ConfigHandlerBase.OIDCValidateLifetime))]
+        [TestCase(ConfigHandlerBase.UseSecurityHeadersKey, nameof(ConfigHandlerBase.UseSecurityHeaders))]
+        public void SecuritySwitchesShouldBeEnabledByDefault(string configKey, string configPropertyName)
+        {
+            // Arrange
+            var configHandler = CreateProductionAWSConfigHandler();
+            var mockConfigurationSection = this.mockRepository.Create<IConfigurationSection>();
+
+            _ = mockConfigurationSection.SetupGet(c => c.Value)
+                .Returns((string)null);
+
+            _ = mockConfigurationSection.SetupGet(c => c.Path)
+                .Returns(string.Empty);
+
+            _ = this.mockConfiguration.Setup(c => c.GetSection(configKey))
+                .Returns(mockConfigurationSection.Object);
+
+            // Act
+            var result = (bool)configHandler
+                                .GetType()
+                                .GetProperty(configPropertyName)
+                                .GetValue(configHandler, null);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestCase(ConfigHandlerBase.OIDCValidateActorKey, nameof(ConfigHandlerBase.OIDCValidateActor))]
+        [TestCase(ConfigHandlerBase.OIDCValidateTokenReplayKey, nameof(ConfigHandlerBase.OIDCValidateTokenReplay))]
+        public void SecuritySwitchesShouldBeDisabledByDefault(string configKey, string configPropertyName)
+        {
+            // Arrange
+            var configHandler = CreateProductionAWSConfigHandler();
+            var mockConfigurationSection = this.mockRepository.Create<IConfigurationSection>();
+
+            _ = mockConfigurationSection.SetupGet(c => c.Value)
+                .Returns((string)null);
+
+            _ = mockConfigurationSection.SetupGet(c => c.Path)
+                .Returns(string.Empty);
+
+            _ = this.mockConfiguration.Setup(c => c.GetSection(configKey))
+                .Returns(mockConfigurationSection.Object);
+
+            // Act
+            var result = (bool)configHandler
+                                .GetType()
+                                .GetProperty(configPropertyName)
+                                .GetValue(configHandler, null);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestCase(ConfigHandlerBase.IsLoRaFeatureEnabledKey, nameof(ConfigHandlerBase.IsLoRaEnabled))]
+        public void SettingsShouldGetBoolFromAppSettings(string configKey, string configPropertyName)
+        {
+            // Arrange
+            var expected = false;
+            var productionConfigHandler = CreateProductionAWSConfigHandler();
+
+            _ = this.mockConfiguration.SetupGet(c => c[It.Is<string>(x => x == configKey)])
+                .Returns(Convert.ToString(expected, CultureInfo.InvariantCulture));
+
+            // Act
+            var result = productionConfigHandler
+                                .GetType()
+                                .GetProperty(configPropertyName)
+                                .GetValue(productionConfigHandler, null);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+
+            // Arrange
+            expected = true;
+
+            _ = this.mockConfiguration.SetupGet(c => c[It.Is<string>(x => x == configKey)])
+                .Returns(Convert.ToString(expected, CultureInfo.InvariantCulture));
+
+            // Act
+            result = productionConfigHandler
+                                .GetType()
+                                .GetProperty(configPropertyName)
+                                .GetValue(productionConfigHandler, null);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+            this.mockRepository.VerifyAll();
+        }
+
+        [Test]
+        public void SyncDatabaseJobRefreshIntervalInMinutesConfigMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.SyncDatabaseJobRefreshIntervalInMinutes.Should().Be(5);
+        }
+
+        [Test]
+        public void MetricExporterRefreshIntervalInSecondsConfigMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.MetricExporterRefreshIntervalInSeconds.Should().Be(30);
+        }
+
+        [Test]
+        public void MetricLoaderRefreshIntervalInMinutesConfigMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.MetricLoaderRefreshIntervalInMinutes.Should().Be(10);
+        }
+
+        [Test]
+        public void IdeasEnabledMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IdeasEnabled.Should().BeFalse();
+        }
+
+        [Test]
+        public void IdeasUrlMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IdeasUrl.Should().BeEmpty();
+        }
+
+        [Test]
+        public void IdeasAuthenticationHeaderMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IdeasAuthenticationHeader.Should().Be("Ocp-Apim-Subscription-Key");
+        }
+
+        [Test]
+        public void IdeasAuthenticationTokenMustHaveDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IdeasAuthenticationToken.Should().BeEmpty();
+        }
+
+        [Test]
+        public void IoTHubEventHubEndpoint_GetDefaultValue_ReturnsEmpty()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IoTHubEventHubEndpoint.Should().BeEmpty();
+        }
+
+        [Test]
+        public void IoTHubEventHubConsumerGroup_GetDefaultValue_ReturnsExpectedDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.IoTHubEventHubConsumerGroup.Should().Be("iothub-portal");
+        }
+
+        [Test]
+        public void DbProviderKeyShouldBeExpectedDefaultValue()
+        {
+            // Arrange
+            var productionAWSConfigHandler = new ProductionAWSConfigHandler(new ConfigurationManager());
+
+            // Assert
+            _ = productionAWSConfigHandler.DbProvider.Should().Be(DbProviders.PostgreSQL);
+        }
+    }
+}


### PR DESCRIPTION
- Add AWS & Azure specific config handlers
- Add AWSS3Storage configuration
- Throw exception if CloudProvider is undefined or unknown


## Description

What's new?

- Fix #1925 
- Fix #1928 

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other