### PR TITLE
Replace deprecated Palette by PaletteLight

### DIFF
--- a/src/AzureIoTHub.Portal.Client/Constants/Theme.cs
+++ b/src/AzureIoTHub.Portal.Client/Constants/Theme.cs
@@ -9,7 +9,7 @@ namespace AzureIoTHub.Portal.Client.Constants
     {
         public static readonly MudTheme CurrentTheme = new()
         {
-            Palette = new Palette
+            Palette = new PaletteLight
             {
                 Background = "#efefef"
             }

--- a/src/AzureIoTHub.Portal.Tests.Unit/Client/Constants/ThemeTests.cs
+++ b/src/AzureIoTHub.Portal.Tests.Unit/Client/Constants/ThemeTests.cs
@@ -5,6 +5,7 @@ namespace AzureIoTHub.Portal.Tests.Unit.Client.Constants
 {
     using AzureIoTHub.Portal.Client.Constants;
     using FluentAssertions;
+    using MudBlazor;
     using NUnit.Framework;
 
     [TestFixture]
@@ -20,6 +21,7 @@ namespace AzureIoTHub.Portal.Tests.Unit.Client.Constants
             var currentTheme = Theme.CurrentTheme;
 
             // Assert
+            _ = currentTheme.Palette.GetType().Should().Be(typeof(PaletteLight));
             _ = currentTheme.Palette.Background.ToString().Should().Be(expectedPaletteBackground);
         }
     }


### PR DESCRIPTION
## Description

What's new?

- Palette is obsolete and will be abstract in a future update of Mudblazor. It must be replaced by PaletteLight or PaletteDark or custom implementation. In our case, we need to replace it by PaletteLight.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other