### PR TITLE
Add doc v4-to-v5 migration page

### DIFF
--- a/docs/dev-guide/migrations/v4-to-v5.md
+++ b/docs/dev-guide/migrations/v4-to-v5.md
@@ -1,0 +1,27 @@
+# Migrate from v4 to v5
+
+In this v5, the major change is the integration of AWS in the portal.
+Some changes have also been made at the portal web app settings.
+
+## AWS
+Starting from version 5, the portal now supports `AWS` integration.  
+To learn how to deploy `AWS services` using the portal, please refer to the [Quick Start](/aws/#quick-start) for AWS documentation. It provides step-by-step instructions on setting up and deploying AWS resources using the portal's interface.
+
+## Azure
+To migrate from v4 to v5 `manually`, you have to add `CloudProvider` with `Azure` as default value.  
+You have to add also `Azure__` prefix in all setting to the portal web app.  
+
+| Name | Setting Type | Detail |
+|---|---|---|
+| `CloudProvider` | Application setting | (Possible value `Azure`) The name of the CLoud Provider to run in the portal |
+| `Azure__LoRaRegionRouterConfig__Url` | Application setting  | The Url for LoRa Region Router Configuration |
+| `Azure__LoRaKeyManagement__Url` | Application setting  | The Url for LoRa Key Management |
+| `Azure__LoRaKeyManagement__Code` | Application setting  | The Code for LoRa Key Management |
+| `Azure__LoRaFeature__Enabled` | Application setting  | To enable or disable LoRa Feature |
+| `Azure__IoTHub__ConnectionString` | Connection string  | The IotHub Connection String |
+| `Azure__IoTHub__EventHub__Endpoint` | Connection string  | The IotHub Event Hub compatible endpoint |
+| `Azure__IoTHub__EventHub__ConsumerGroup` | Application setting  | (Default value `iothub-portal`) The name of the consumer group used to to pull data from the IoT Hub |
+| `Azure__IoTDPS__ServiceEndpoint` | Application setting  | The IotDPS Service Endpoint |
+| `Azure__IoTDP__LoRaEnrollmentGroup` | Application setting  | The name of the IotDPS LoRa Enrollment group |
+| `Azure__IoTDPS__DefaultEnrollmentGroup` | Application setting  | The name of the default IotDPS Enrollment group |
+| `Azure__IoTDPS__ConnectionString` | Connection string  | The IotDPS Connection String |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - 'dev-guide/testing/unit-tests-on-blazor-components.md'
     - 'Migrations':
       - 'dev-guide/migrations/v3-to-v4.md'
+      - 'dev-guide/migrations/v4-to-v5.md'
     - 'Project conception':
       - 'dev-guide/conception/diagrams.md'
   - Concepts: 'concepts.md'


### PR DESCRIPTION
## Description
The v5 of the portal will be released and we need to document the breaking changes that occurred on the portal.
At least: 

- Introduction of ``CloudProvider`` setting in the that that is required
- Move Azure specific settings with an ``Azure__`` prefix

What's new?

- #2228 

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other