### PR TITLE
Feature: Remove unused and depcrecated package Microsoft.AspNetCore.Components.Web.Extensions

### DIFF
--- a/src/IoTHub.Portal.Client/IoTHub.Portal.Client.csproj
+++ b/src/IoTHub.Portal.Client/IoTHub.Portal.Client.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
     <PackageReference Include="FluentValidation" Version="11.6.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web.Extensions" Version="5.0.0-preview9.20513.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

What's new?

- Uninstall Microsoft.AspNetCore.Components.Web.Extensions dependency: The package Microsoft.AspNetCore.Components.Web.Extensions is not used and it is deprecated. 

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other