### PR TITLE
Fix #2675 - Unable to create edge device model since the module version is required

### DIFF
--- a/src/IoTHub.Portal.Shared/Models/v1.0/IoTEdgeModule.cs
+++ b/src/IoTHub.Portal.Shared/Models/v1.0/IoTEdgeModule.cs
@@ -51,7 +51,6 @@ namespace IoTHub.Portal.Models.v10
         /// </summary>
         public List<IoTEdgeModuleCommand> Commands { get; set; } = new List<IoTEdgeModuleCommand>();
 
-        [Required(ErrorMessage = "The component version is required.", AllowEmptyStrings = true)]
         public string Version { get; set; } = default!;
     }
 }


### PR DESCRIPTION
## Description
This Pull Request resolves the issue related to the automatic version management of IoT Edge modules by Azure. Previously, the `Version` field in `IoTEdgeModule.cs` was marked as required, which is no longer necessary since Azure manages this field automatically.

## What kind of change does this PR introduce?
- [x] Bugfix #2675 

## Details of the Change
The following line has been removed from `IoTEdgeModule.cs`:

```csharp
[Required(ErrorMessage = "The component version is required.", AllowEmptyStrings = true)]
```

This change makes the Version field non-required, correcting the issue where the Version value was sometimes missing or improperly managed during the creation or updating of IoT Edge Device Models.