### PR TITLE
Update documentation of OpenID Connect Setup Instructions for Azure

### DIFF
--- a/docs/b2c-applications.md
+++ b/docs/b2c-applications.md
@@ -17,12 +17,13 @@ By the end, you should have recorded the following information:
 
 1. After creating your Azure AD B2C Tenant and registering your applications, you need to set up OpenID Connect to secure your applications. Here’s how to find your OpenID authority and OpenID metadata URL:
     1. **Determine your OpenID Authority**:
-    * Your OpenID Authority is the issuer URL of your Azure AD B2C Tenant. It typically follows the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/`.
-    * Replace `<tenant-name>` with your actual tenant name.
-    2. **Find your OpenID Metadata URL**:
-    * The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
-    * Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
-    3. Make sure to record the OpenID authority and OpenID metadata URL for future configuration steps.
+        * Your OpenID Authority is the issuer URL of your Azure AD B2C Tenant. It typically follows the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/`.
+        * Replace `<tenant-name>` with your actual tenant name.
+    1. **Find your OpenID Metadata URL**:
+        * The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
+        * Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
+    1. Make sure to record the OpenID authority and OpenID metadata URL for future configuration steps.
+    
 1. Configure the requiered AD Applications.
     1. Create the **IoT Hub Portal API** Application:
         * Select **App registrations**, and then select **New registration**.

--- a/docs/b2c-applications.md
+++ b/docs/b2c-applications.md
@@ -14,6 +14,17 @@ By the end, you should have recorded the following information:
 
 1. Create an Azure AD B2C Tenant (see: [https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant#create-an-azure-ad-b2c-tenant](https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-tenant#create-an-azure-ad-b2c-tenant))
     * Record the **tenant ID** and the **tenant name**.
+
+1. After creating your Azure AD B2C Tenant and registering your applications, you need to set up OpenID Connect to secure your applications. Here’s how to find your OpenID authority and OpenID metadata URL:
+
+    1. **Determine your OpenID Authority**:
+    - Your OpenID Authority is the issuer URL of your Azure AD B2C Tenant. It typically follows the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/`.
+    - Replace `<tenant-name>` with your actual tenant name.
+
+    2. **Find your OpenID Metadata URL**:
+    - The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
+    - Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
+    3. Make sure to record the OpenID authority and OpenID metadata URL for future configuration steps.
 1. Configure the requiered AD Applications.
     1. Create the **IoT Hub Portal API** Application:
         * Select **App registrations**, and then select **New registration**.

--- a/docs/b2c-applications.md
+++ b/docs/b2c-applications.md
@@ -23,7 +23,6 @@ By the end, you should have recorded the following information:
         * The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
         * Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
     1. Make sure to record the OpenID authority and OpenID metadata URL for future configuration steps.
-    
 1. Configure the requiered AD Applications.
     1. Create the **IoT Hub Portal API** Application:
         * Select **App registrations**, and then select **New registration**.

--- a/docs/b2c-applications.md
+++ b/docs/b2c-applications.md
@@ -16,14 +16,12 @@ By the end, you should have recorded the following information:
     * Record the **tenant ID** and the **tenant name**.
 
 1. After creating your Azure AD B2C Tenant and registering your applications, you need to set up OpenID Connect to secure your applications. Here’s how to find your OpenID authority and OpenID metadata URL:
-
     1. **Determine your OpenID Authority**:
-    - Your OpenID Authority is the issuer URL of your Azure AD B2C Tenant. It typically follows the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/`.
-    - Replace `<tenant-name>` with your actual tenant name.
-
+    * Your OpenID Authority is the issuer URL of your Azure AD B2C Tenant. It typically follows the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/`.
+    * Replace `<tenant-name>` with your actual tenant name.
     2. **Find your OpenID Metadata URL**:
-    - The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
-    - Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
+    * The OpenID Metadata URL for Azure AD B2C tenants is usually in the format: `https://<tenant-name>.b2clogin.com/<tenant-name>.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=<policy-name>`.
+    * Replace `<tenant-name>` and `<policy-name>` with your actual tenant name and the policy name you are using (like B2C_1_SignUpSignIn).
     3. Make sure to record the OpenID authority and OpenID metadata URL for future configuration steps.
 1. Configure the requiered AD Applications.
     1. Create the **IoT Hub Portal API** Application:


### PR DESCRIPTION
## Description
#2601 

What's new?

- Added detailed instructions for setting up OpenID Connect in the Azure AD B2C tenant documentation. This includes steps to determine the OpenID Authority and find the OpenID Metadata URL, ensuring comprehensive guidance for users during Azure deployment setup.


## What kind of change does this PR introduce?

- [x] Documentation content changes
