### PR TITLE
Feature: Dependabot ignores major versions on nuget packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    # Maintain dependencies for the web client
-  - package-ecosystem: "npm"
-    directory: "/src/IoTHub.Portal/Client"
-    schedule:
-      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     directory: "/src/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # Maintain dependencies for the web client
   - package-ecosystem: "npm"
     directory: "/src/IoTHub.Portal/Client"


### PR DESCRIPTION
## Description

What's new?

- FIx #2682 
- Remove dependabot npm ecosystem: No more used by IotHUb Portal client

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other