### PR TITLE
Fix/connection state update 2574

### DIFF
--- a/src/IoTHub.Portal.Infrastructure/Jobs/SyncEdgeDeviceJob.cs
+++ b/src/IoTHub.Portal.Infrastructure/Jobs/SyncEdgeDeviceJob.cs
@@ -12,6 +12,7 @@ namespace IoTHub.Portal.Infrastructure.Jobs
     using IoTHub.Portal.Domain;
     using IoTHub.Portal.Domain.Entities;
     using IoTHub.Portal.Domain.Repositories;
+    using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
     using Quartz;
@@ -130,11 +131,15 @@ namespace IoTHub.Portal.Infrastructure.Jobs
             var twinWithModule = await this.externalDeviceService.GetDeviceTwinWithModule(twin.DeviceId);
             var twinWithClient = await this.externalDeviceService.GetDeviceTwinWithEdgeHubModule(twin.DeviceId);
 
+            var connectionState = twin.ConnectionState == DeviceConnectionState.Connected ? "Connected" : "Disconnected";
+
             var device = this.mapper.Map<EdgeDevice>(twin,opts =>
             {
                 opts.Items["TwinModules"] = twinWithModule;
                 opts.Items["TwinClient"] = twinWithClient;
             }) ;
+
+            device.ConnectionState = connectionState;
 
             var deviceEntity = await this.edgeDeviceRepository.GetByIdAsync(device.Id, d => d.Tags);
 


### PR DESCRIPTION
## Description

Fix of issue #2574 

What's new?

- The application now correctly reflects the `ConnectionState` of devices. When the `ConnectionState` in Azure IoT Hub is set to `Connected`, this status is accurately updated. So the 'reboot' and 'log' buttons are no enabled instead of always disabled.

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other