### PR TITLE
Bugfix: Replace node build image by dotnet/sdk image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,32 +4,23 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM node:14-bullseye AS build
-
-RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN rm packages-microsoft-prod.deb
-RUN  apt-get update; \
-	  apt-get install -y apt-transport-https && \
-	  apt-get update && \
-	  apt-get install -y dotnet-sdk-8.0
-
-FROM build AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_VERSION=1.2.3
 ARG GITHUB_RUN_NUMBER=4
 WORKDIR /src
+RUN ls
 COPY ["IoTHub.Portal.Server/IoTHub.Portal.Server.csproj", "IoTHub.Portal.Server/"]
 COPY ["IoTHub.Portal.Shared/IoTHub.Portal.Shared.csproj", "IoTHub.Portal.Shared/"]
 COPY ["IoTHub.Portal.Client/IoTHub.Portal.Client.csproj", "IoTHub.Portal.Client/"]
 RUN dotnet restore "IoTHub.Portal.Server/IoTHub.Portal.Server.csproj"
 COPY . .
 WORKDIR "/src/IoTHub.Portal.Server"
-RUN dotnet build "IoTHub.Portal.Server.csproj" -c Release -o /app/build -p:Version="${BUILD_VERSION}.${GITHUB_RUN_NUMBER}" -p:ClientAssetsRestoreCommand="npm ci"
+RUN dotnet build "IoTHub.Portal.Server.csproj" -c Release -o /app/build -p:Version="${BUILD_VERSION}.${GITHUB_RUN_NUMBER}"
 
-FROM builder AS publish
+FROM build AS publish
 ARG BUILD_VERSION=1.2.3
 ARG GITHUB_RUN_NUMBER=4
-RUN dotnet publish "IoTHub.Portal.Server.csproj" -c Release -o /app/publish  -p:Version="${BUILD_VERSION}.${GITHUB_RUN_NUMBER}" -p:ClientAssetsRestoreCommand="npm ci"
+RUN dotnet publish "IoTHub.Portal.Server.csproj" -c Release -o /app/publish  -p:Version="${BUILD_VERSION}.${GITHUB_RUN_NUMBER}"
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
## Description

What's new?

- Replace node build image by dotnet/sdk image to build IoT Hub Portal
- Remove unused build params:  -p:ClientAssetsRestoreCommand="npm ci"

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other